### PR TITLE
Make CVE Docs pages work better over https://

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,7 @@ description: > # this means to ignore newlines until "baseurl:"
   vulnerabilities. CVE's common identifiers enable data exchange between
   security products and provide a baseline index point for evaluating coverage
   of tools and services.
-baseurl: "" # the subpath of your site, e.g. /blog
+baseurl: "/docs" # the subpath of your site, e.g. /blog
 
 # Build settings
 markdown: kramdown

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,7 +4,7 @@
     <p>
       Use of the Common Vulnerabilities and Exposures List and the associated
       references from this Web site are subject to the
-      <a href="{{ site.github.url }}/terms.html">Terms of Use</a>.
+      <a href="{{ site.baseurl }}/terms.html">Terms of Use</a>.
       For more information, please email
       <a href="mailto:cve@mitre.org">cve@mitre.org</a>. <br />
 
@@ -27,4 +27,4 @@
 <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
 <!-- Include all compiled plugins (below), or include individual files as needed -->
-<script src="{{ site.github.url }}/js/bootstrap.min.js"></script>
+<script src="{{ site.baseurl }}/js/bootstrap.min.js"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,9 +6,9 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <link href="{{ site.github.url }}/css/site.css" rel="stylesheet">
+  <link href="{{ site.baseurl }}/css/site.css" rel="stylesheet">
   <!-- Bootstrap -->
-  <link href="{{ site.github.url }}/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ site.baseurl }}/css/bootstrap.min.css" rel="stylesheet">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.github.url }}">
   <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->

--- a/cna/application-guidance.md
+++ b/cna/application-guidance.md
@@ -47,7 +47,7 @@ For background information, go to:
 
 </p><p>
 
-<a target="_blank" href="http://cve.mitre.org/cve/editorial_policies/cd_abstraction.html">
+<a target="_blank" href="https://cve.mitre.org/cve/editorial_policies/cd_abstraction.html">
 CVE Abstraction Content Decisions: Rationale and Application
 </a>
 
@@ -370,7 +370,7 @@ identifier; instead, consult MITRE (issue is complex)
 			Are X and Y different bug types? (e.g. buffer overflow, SQL injection,
 			NULL pointer dereference?)
 			See
-			<a href="http://cve.mitre.org/cve/editorial_policies/cd_abstraction.html#identifying_different_bug_types">
+			<a href="https://cve.mitre.org/cve/editorial_policies/cd_abstraction.html#identifying_different_bug_types">
 			Guidance on Identifying Different Bug Types</a>
 		</td>
 	</tr>

--- a/index.md
+++ b/index.md
@@ -3,7 +3,7 @@ title: Common Vulnerabilities and Exposures
 layout: page
 ---
 
-<img class="center-block img-responsive" src="{{ site.github.url }}/img/cve-logo-600.png" alt="CVE Logo" />
+<img class="center-block img-responsive" src="{{ site.baseurl }}/img/cve-logo-600.png" alt="CVE Logo" />
 
 <div class="row">
 

--- a/requester/reservation-guidelines.md
+++ b/requester/reservation-guidelines.md
@@ -19,10 +19,10 @@ Here are the five factors that most often affect determination of the
 correct number of new CVE IDs:
 
 A. Duplicate search. Duplicates may be found by searching
-http://cve.mitre.org/cve/cve.html and also by general web searches (at
+https://cve.mitre.org/cve/cve.html and also by general web searches (at
 any moment in time, not every assigned CVE ID is covered on the
 cve.mitre.org web site). Also, if you have previously contacted
-another organization on the http://cve.mitre.org/cve/cna.html list, a
+another organization on the https://cve.mitre.org/cve/cna.html list, a
 CVE ID assignment may already exist and should not be duplicated.
 
 B. Scope of CVE. CVE IDs are for cases in which the primary method of
@@ -108,7 +108,7 @@ The basic process is:
 Following is some background information, which may help you to
 understand the rationales for the process.
 
-1. See http://cve.mitre.org/cve/identifiers/index.html for
+1. See https://cve.mitre.org/cve/identifiers/index.html for
    details on how vulnerabilities are included in CVE.
 
 2. As more and more CVEs are included in announcements of new
@@ -139,7 +139,7 @@ understand the rationales for the process.
 
 2. You must make sure that your issue is not already a duplicate of an
    existing CVE entry by performing a keyword search on the CVE web
-   site at http://cve.mitre.org/cve/ .
+   site at https://cve.mitre.org/cve/ .
 
 3. You should follow coordinated disclosure practices as described in
    the next section.
@@ -219,7 +219,7 @@ publicize the vulnerability.
 You request a CVE number from a CVE Numbering Authority (CNA).  CNAs
 obtain pools of "blank" candidate numbers from MITRE, and use those
 pools to assign candidates to specific issues.  See
-http://cve.mitre.org/cve/cna.html for a list.
+https://cve.mitre.org/cve/cna.html for a list.
 
 Most major OS vendors use CVE numbers, even if they are not a CNA;
 they generally obtain them from other CNAs.  You could ask them for a
@@ -237,7 +237,7 @@ number of CVE IDs.
 However, the request will have much higher priority if you explain
 its relationship to the CVE coverage goals stated at:
 
-  http://cve.mitre.org/cve/data_sources_product_coverage.html
+  https://cve.mitre.org/cve/data_sources_product_coverage.html
 
 There are three aspects to this:
 
@@ -351,13 +351,13 @@ You can include a paragraph such as the following:
 
   The Common Vulnerabilities and Exposures (CVE) project has assigned
   the name CVE-YYYY-NNNN to this issue. This is an entry on the CVE
-  list (http://cve.mitre.org), which standardizes names for security
+  list (https://cve.mitre.org), which standardizes names for security
   problems.
 
 If you can not include this text due to space limitations, then try to
 include a URL to the CVE:
 
-   http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-YYYY-NNNN
+   https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-YYYY-NNNN
 
 You can also just say something like:
 
@@ -398,7 +398,7 @@ MITRE will then update the CVE information on the CVE web site with a
 proper description, references, etc.
 
 The CVE information will also be updated in the National Vulnerability
-Database (NVD) at http://nvd.nist.gov.
+Database (NVD) at https://nvd.nist.gov.
 
 
 
@@ -416,13 +416,13 @@ disclosure practices that lead to more accurate CVE entries.
 2. "Vulnerability Disclosure Framework", US Department of Homeland
     Security.  January 2004.
 
-      http://www.dhs.gov/xlibrary/assets/vdwgreport.pdf
+      https://www.dhs.gov/xlibrary/assets/vdwgreport.pdf
 
 3. "Responsible Vulnerability Disclosure Process", IETF draft
    document, Christey/Wysopal.  February 2002.
 
-      http://tools.ietf.org/html/draft-christey-wysopal-vuln-disclosure-00
+      https://tools.ietf.org/html/draft-christey-wysopal-vuln-disclosure-00
 
 4. "RFPolicy 2.0", Rain Forest Puppy.  2000.
 
-      http://packetstormsecurity.org/files/view/23364/rfpolicy-2.0.txt
+      https://packetstormsecurity.org/files/view/23364/rfpolicy-2.0.txt


### PR DESCRIPTION
GitHub supports https:// for all *.github.io URLs. Update
all links to use relative links where possible so that
https:// works fine (and doesn't cause mixed content errors).

Also, update URLs in documentation where appropriate to use https://.
